### PR TITLE
Fix BatchRequest dataclass ordering and provider mixins

### DIFF
--- a/ia_provider/anthropic.py
+++ b/ia_provider/anthropic.py
@@ -21,7 +21,7 @@ except ImportError:
 # Provider Anthropic avec support batch
 # =============================================================================
 
-class AnthropicProvider(BaseProvider, AnthropicBatchMixin):
+class AnthropicProvider(AnthropicBatchMixin, BaseProvider):
     """Provider pour le modèle Anthropic claude-sonnet-4 avec support des batches"""
     
     def __init__(self, model_name: str, api_key: str):

--- a/ia_provider/batch.py
+++ b/ia_provider/batch.py
@@ -32,9 +32,9 @@ except ImportError:
 class BatchRequest:
     """Représente une requête unique pour l'API Batch d'OpenAI."""
     custom_id: str
+    body: Dict
     method: str = "POST"
     url: str = "/v1/chat/completions"
-    body: Dict
 
     def __post_init__(self):
         """Validation après initialisation."""

--- a/ia_provider/gpt5.py
+++ b/ia_provider/gpt5.py
@@ -21,7 +21,7 @@ except ImportError:
 # Provider GPT-5 avec support batch
 # =============================================================================
 
-class GPT5Provider(BaseProvider, OpenAIBatchMixin):
+class GPT5Provider(OpenAIBatchMixin, BaseProvider):
     """
     Provider spécifique pour GPT-5 avec ses paramètres uniques et support des batches.
     GPT-5 introduit reasoning_effort et verbosity à la place de temperature/top_p.

--- a/ia_provider/openai.py
+++ b/ia_provider/openai.py
@@ -21,7 +21,7 @@ except ImportError:
 # Provider OpenAI avec support batch
 # =============================================================================
 
-class OpenAIProvider(BaseProvider, OpenAIBatchMixin):
+class OpenAIProvider(OpenAIBatchMixin, BaseProvider):
     """Provider pour le modèle OpenAI gpt-4.1 avec support des batches"""
     
     def __init__(self, model_name: str, api_key: str):


### PR DESCRIPTION
## Summary
- Correct BatchRequest dataclass field order so non-default fields precede defaults
- Place batch mixins before BaseProvider in provider classes to satisfy abstract `submit_batch`

## Testing
- `pytest -q`
- `python app.py`


------
https://chatgpt.com/codex/tasks/task_b_68ab7c628c9c832b88c909facb66010c