### PR TITLE
feat: unify batch statuses across providers

### DIFF
--- a/app.py
+++ b/app.py
@@ -528,7 +528,12 @@ with st.expander("Suivi des lots (Batches)"):
                     history = batch_manager.get_history(limit=20)
 
                     if history:
-                        st.dataframe(history)
+                        import pandas as pd
+                        df = pd.DataFrame(history)
+                        if 'unified_status' in df.columns:
+                            st.dataframe(df[['id', 'unified_status', 'created_at', 'provider']])
+                        else:
+                            st.dataframe(df)
                     else:
                         st.info("Aucun lot trouvé pour ce provider.")
             except Exception as e:

--- a/test_batch_unified_status.py
+++ b/test_batch_unified_status.py
@@ -1,0 +1,74 @@
+import pytest
+from types import SimpleNamespace
+from ia_provider.batch import BatchJobManager
+
+
+@pytest.mark.parametrize("raw,expected", [
+    ("in_progress", "running"),
+    ("completed", "completed"),
+    ("failed", "failed"),
+    ("cancelled", "failed"),
+])
+def test_unify_status_openai_mapping(raw, expected):
+    manager = BatchJobManager(api_key="", provider_type="openai")
+    result = manager._unify_status({"status": raw, "provider": "openai"})
+    assert result["unified_status"] == expected
+    assert result["status"] == raw
+
+
+@pytest.mark.parametrize("raw,expected", [
+    ("processing", "running"),
+    ("ended", "completed"),
+    ("expired", "failed"),
+])
+def test_unify_status_anthropic_mapping(raw, expected):
+    manager = BatchJobManager(api_key="", provider_type="anthropic")
+    result = manager._unify_status({"status": raw, "provider": "anthropic"})
+    assert result["unified_status"] == expected
+    assert result["status"] == raw
+
+
+def test_get_status_and_history_include_unified_status_openai():
+    manager = BatchJobManager(api_key="", provider_type="openai")
+
+    batch_status = SimpleNamespace(
+        id="batch_b1",
+        status="in_progress",
+        created_at=0,
+        endpoint="/v1/chat",
+        completion_window="24h",
+        request_counts=None,
+        output_file_id=None,
+        error_file_id=None,
+        input_file_id=None,
+        metadata={},
+    )
+
+    batch_history = SimpleNamespace(
+        id="b2",
+        status="completed",
+        created_at=0,
+        endpoint="/v1/chat",
+        completion_window="24h",
+        request_counts=None,
+        output_file_id=None,
+        error_file_id=None,
+        metadata={},
+    )
+
+    manager.client = SimpleNamespace(
+        batches=SimpleNamespace(
+            retrieve=lambda batch_id: batch_status,
+            list=lambda limit: SimpleNamespace(data=[batch_history]),
+        )
+    )
+
+    status = manager.get_status("batch_b1")
+    assert status["status"] == "in_progress"
+    assert status["unified_status"] == "running"
+
+    history = manager.get_history(limit=1)
+    assert len(history) == 1
+    assert history[0]["status"] == "completed"
+    assert history[0]["unified_status"] == "completed"
+    assert "unified_status" in status and "unified_status" in history[0]


### PR DESCRIPTION
## Summary
- normalize batch statuses from OpenAI and Anthropic to a unified `running/completed/failed/unknown` scheme
- expose `unified_status` in batch history and status APIs and display it in the Streamlit app
- add tests covering status mapping and unified status exposure

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68aba4b55854832b9647b6366a1c8f3f