### PR TITLE
feat: expose unified batch status across providers

### DIFF
--- a/app.py
+++ b/app.py
@@ -530,6 +530,7 @@ with st.expander("Suivi des lots (Batches)"):
                     if history:
                         import pandas as pd
                         df = pd.DataFrame(history)
+                        # Afficher le statut unifié pour masquer les spécificités des providers
                         if 'unified_status' in df.columns:
                             st.dataframe(df[['id', 'unified_status', 'created_at', 'provider']])
                         else:

--- a/ia_provider/batch.py
+++ b/ia_provider/batch.py
@@ -219,7 +219,13 @@ class BatchJobManager:
                 self.client = None
 
     def _unify_status(self, batch_info: Dict[str, Any]) -> Dict[str, Any]:
-        """Ajoute un statut unifié à un dictionnaire d'informations de lot."""
+        """Ajoute un statut unifié à un dictionnaire d'informations de lot.
+
+        Normalise les valeurs spécifiques au provider pour exposer un ensemble
+        commun de statuts : ``running``, ``completed``, ``failed`` ou
+        ``unknown``. Le champ de statut original est conservé pour les besoins
+        de débogage.
+        """
 
         unified_status = "unknown"
         provider = batch_info.get('provider', self.provider_type)

--- a/test_ia_provider.py
+++ b/test_ia_provider.py
@@ -8,6 +8,7 @@ import pytest
 import os
 from unittest.mock import Mock, MagicMock, patch
 from typing import Dict, Any
+from types import SimpleNamespace
 
 # Import du module à tester
 from ia_provider import (
@@ -22,6 +23,7 @@ from ia_provider import (
 from ia_provider.openai import OpenAIProvider
 from ia_provider.anthropic import AnthropicProvider
 from ia_provider.gpt5 import GPT5Provider
+from ia_provider.batch import BatchJobManager
 
 
 # =============================================================================
@@ -49,6 +51,80 @@ def sample_messages():
         {"role": "assistant", "content": "Bonjour! Comment puis-je vous aider?"},
         {"role": "user", "content": "Quelle est la capitale de la France?"}
     ]
+
+
+# =============================================================================
+# Tests de normalisation des statuts de batch
+# =============================================================================
+
+class TestBatchStatusUnification:
+    @pytest.mark.parametrize("raw,expected", [
+        ("in_progress", "running"),
+        ("completed", "completed"),
+        ("failed", "failed"),
+        ("cancelled", "failed"),
+    ])
+    def test_unify_status_openai_mapping(self, raw, expected):
+        manager = BatchJobManager(api_key="", provider_type="openai")
+        result = manager._unify_status({"status": raw, "provider": "openai"})
+        assert result["unified_status"] == expected
+        assert result["status"] == raw
+
+    @pytest.mark.parametrize("raw,expected", [
+        ("processing", "running"),
+        ("ended", "completed"),
+        ("expired", "failed"),
+    ])
+    def test_unify_status_anthropic_mapping(self, raw, expected):
+        manager = BatchJobManager(api_key="", provider_type="anthropic")
+        result = manager._unify_status({"status": raw, "provider": "anthropic"})
+        assert result["unified_status"] == expected
+        assert result["status"] == raw
+
+    def test_get_status_and_history_include_unified_status_openai(self):
+        manager = BatchJobManager(api_key="", provider_type="openai")
+
+        batch_status = SimpleNamespace(
+            id="batch_b1",
+            status="in_progress",
+            created_at=0,
+            endpoint="/v1/chat",
+            completion_window="24h",
+            request_counts=None,
+            output_file_id=None,
+            error_file_id=None,
+            input_file_id=None,
+            metadata={},
+        )
+
+        batch_history = SimpleNamespace(
+            id="b2",
+            status="completed",
+            created_at=0,
+            endpoint="/v1/chat",
+            completion_window="24h",
+            request_counts=None,
+            output_file_id=None,
+            error_file_id=None,
+            metadata={},
+        )
+
+        manager.client = SimpleNamespace(
+            batches=SimpleNamespace(
+                retrieve=lambda batch_id: batch_status,
+                list=lambda limit: SimpleNamespace(data=[batch_history]),
+            )
+        )
+
+        status = manager.get_status("batch_b1")
+        assert status["status"] == "in_progress"
+        assert status["unified_status"] == "running"
+
+        history = manager.get_history(limit=1)
+        assert len(history) == 1
+        assert history[0]["status"] == "completed"
+        assert history[0]["unified_status"] == "completed"
+        assert "unified_status" in status and "unified_status" in history[0]
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- document unified batch status mapping in `BatchJobManager`
- note unified status column in Streamlit batch history
- add tests ensuring status mapping and presence in API outputs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68aba61cead8832b99b9f0530ae396a2