### PR TITLE
Refactor batch result handling

### DIFF
--- a/app.py
+++ b/app.py
@@ -561,6 +561,8 @@ with st.expander("Suivi des lots (Batches)"):
                 with st.spinner("Récupération des résultats..."):
                     results = batch_manager.get_results(batch_id_input)
 
+                # Chaque élément de ``results`` est un ``BatchResult`` décrivant
+                # le succès ou l'échec de la requête correspondante.
                 if results:
                     for res in results:
                         if res.status == 'succeeded':

--- a/ia_provider/batch.py
+++ b/ia_provider/batch.py
@@ -431,11 +431,12 @@ class BatchJobManager:
             print(f"❌ Erreur recherche batch {batch_id}: {str(e)}")
             return None
     
-    def get_results(self, batch_id: str, clean_json: bool = True) -> List[BatchResult]:
+    def get_results(self, batch_id: str) -> List[BatchResult]:
         """Télécharge et parse les résultats d'un batch.
 
-        Retourne toujours une liste de ``BatchResult`` où chaque élément
-        représente soit un succès soit une erreur associée à une requête du lot.
+        Chaque ligne des fichiers de sortie ou d'erreur est convertie en
+        ``BatchResult`` décrivant soit une réussite, soit une erreur pour la
+        requête identifiée par ``custom_id``.
         """
 
         if not self.client:

--- a/test_ia_provider.py
+++ b/test_ia_provider.py
@@ -572,6 +572,10 @@ class TestSubmitBatchPersists:
 class TestBatchGetResults:
     """Vérifie que get_results retourne des ``BatchResult`` normalisés."""
 
+    # Les tests suivants s'assurent que chaque ligne de sortie d'un batch est
+    # transformée en instance de ``BatchResult`` comportant l'état et les
+    # données brutes associées.
+
     # ------------------------------------------------------------------
     # Utilitaires
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- streamline `get_results` to always yield structured BatchResult entries
- document BatchResult usage in Streamlit UI and tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68abad0006c4832bb2680cd5ed17ea91