### PR TITLE
feat: filter batch parameters like sync

### DIFF
--- a/ia_provider/anthropic.py
+++ b/ia_provider/anthropic.py
@@ -72,8 +72,12 @@ class AnthropicProvider(AnthropicBatchMixin, BaseProvider):
             }
         elif 'thinking' in kwargs:
             params['thinking'] = kwargs['thinking']
-        
+
         return params
+
+    def preparer_parametres_batch(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Prépare et filtre les paramètres pour une requête batch Anthropic."""
+        return self._preparer_parametres_anthropic(**params)
     
     def generer_reponse(self, prompt: str, **kwargs) -> str:
         """

--- a/ia_provider/core.py
+++ b/ia_provider/core.py
@@ -162,6 +162,11 @@ class BaseProvider(ABC):
             APIError: Si le provider ne supporte pas les batches
         """
         pass
+
+    @abstractmethod
+    def preparer_parametres_batch(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Prépare et filtre les paramètres pour une requête de type batch."""
+        pass
     
     def _preparer_parametres(self, **kwargs) -> Dict[str, Any]:
         """

--- a/ia_provider/gpt5.py
+++ b/ia_provider/gpt5.py
@@ -91,8 +91,12 @@ class GPT5Provider(OpenAIBatchMixin, BaseProvider):
         
         # Filtrer les paramètres None
         params = {k: v for k, v in params.items() if v is not None}
-        
+
         return params
+
+    def preparer_parametres_batch(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Prépare et filtre les paramètres pour une requête batch GPT-5."""
+        return self._preparer_parametres_gpt5(**params)
     
     def generer_reponse(self, prompt: str, **kwargs) -> str:
         """

--- a/ia_provider/openai.py
+++ b/ia_provider/openai.py
@@ -60,6 +60,14 @@ class OpenAIProvider(OpenAIBatchMixin, BaseProvider):
         
         # Filtrer pour ne garder que les paramètres supportés
         return {k: v for k, v in params.items() if k in parametres_supportes}
+
+    def preparer_parametres_batch(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Prépare et filtre les paramètres pour une requête batch OpenAI."""
+        prepared_params = self._preparer_parametres(**params)
+        filtered_params = self._filtrer_parametres_openai(prepared_params)
+        if 'max_tokens' in filtered_params and self.model_name.startswith('gpt-4.1'):
+            filtered_params['max_completion_tokens'] = filtered_params.pop('max_tokens')
+        return filtered_params
     
     def generer_reponse(self, prompt: str, **kwargs) -> str:
         """


### PR DESCRIPTION
## Summary
- add batch parameter preparation hook to base provider and implement for OpenAI, GPT-5 and Anthropic
- filter and normalize parameters for OpenAI and GPT-5 batch requests
- reuse Anthropic parameter preparation to strip unsupported options during batch submission

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68ac7f16ed44832bb4dba376e5ae4dec